### PR TITLE
Update exponent_server_sdk to >=1.0.0

### DIFF
--- a/django_notification_system/notification_handlers/expo.py
+++ b/django_notification_system/notification_handlers/expo.py
@@ -2,7 +2,7 @@
 from exponent_server_sdk import (
     PushClient,
     PushMessage,
-    PushResponseError,
+    PushTicketError,
     PushServerError,
     DeviceNotRegisteredError,
 )
@@ -84,7 +84,7 @@ def handle_push_response(notification, response):
 
     Args:
         notification (Notification): The Expo push notification to be sent.
-        response (PushResponse): The Expo push response
+        response (PushTicket): The Expo push response
 
     Returns:
         str: Whether the push has successfully sent, or an error message.
@@ -99,7 +99,7 @@ def handle_push_response(notification, response):
         target_user_record.active = False
         target_user_record.save()
         return "{}: {}".format(type(e), e)
-    except PushResponseError as e:
+    except PushTicketError as e:
         check_and_update_retry_attempts(notification)
         return "{}: {}".format(type(e), e)
     else:

--- a/django_notification_system/tests/management/commands/test_process_notifications.py
+++ b/django_notification_system/tests/management/commands/test_process_notifications.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
-from exponent_server_sdk import PushResponse
+from exponent_server_sdk import PushTicket
 from six import StringIO
 
 from django_notification_system.models import (
@@ -369,11 +369,12 @@ class TestCommand(TestCase):
 
         """
         self.assertEqual(self.dev_user_target.active, True)
-        response = PushResponse(
+        response = PushTicket(
             push_message="",
-            status=PushResponse.ERROR_STATUS,
+            status=PushTicket.ERROR_STATUS,
             message='"adsf" is not a registered push notification recipient',
-            details={'error': PushResponse.ERROR_DEVICE_NOT_REGISTERED}
+            details={'error': PushTicket.ERROR_DEVICE_NOT_REGISTERED},
+            id=PushTicket.id
         )
         handle_push_response(self.dev_notification, response=response)
         self.dev_user_target.refresh_from_db()

--- a/django_notification_system/tests/mock_exponent_server_sdk.py
+++ b/django_notification_system/tests/mock_exponent_server_sdk.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from exponent_server_sdk import PushResponseError, DeviceNotRegisteredError, MessageTooBigError, MessageRateExceededError, PushServerError, PushMessage, PushResponse
+from exponent_server_sdk import PushTicketError, DeviceNotRegisteredError, MessageTooBigError, MessageRateExceededError, PushServerError, PushMessage, PushTicket
 
 
 class MockPushClient(object):
@@ -54,11 +54,12 @@ class MockPushClient(object):
         receipts = []
         for i, message in enumerate(push_messages):
             payload = message.get_payload()
-            receipts.append(PushResponse(
+            receipts.append(PushTicket(
                 push_message=message,
-                status=PushResponse.SUCCESS_STATUS,
+                status=PushTicket.SUCCESS_STATUS,
                 message='',
-                details=None))
+                details=None,
+                id=id))
             if payload.get('sound', 'default') != 'default':
                 raise PushServerError('Request failed', {})
 
@@ -71,7 +72,7 @@ class MockPushClient(object):
             push_message: A single PushMessage object.
 
         Returns:
-           A PushResponse object which contains the results.
+           A PushTicket object which contains the results.
         """
         return self.publish_multiple([push_message])[0]
 
@@ -82,6 +83,6 @@ class MockPushClient(object):
             push_messages: An array of PushMessage objects.
 
         Returns:
-           An array of PushResponse objects which contains the results.
+           An array of PushTicket objects which contains the results.
         """
         return self._publish_internal(push_messages)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 Django>=3.1.3
 
-html2text==2018.1.9
-twilio==6.29.1
-exponent_server_sdk==0.3.1          # A module used to send push notifications to Exponent Experiences
+html2text>=2018.1.9
+twilio>=6.29.1
+exponent_server_sdk>=1.0.2          # A module used to send push notifications to Exponent Experiences
 
-Sphinx==2.2.0                       # Documentation Tool
+Sphinx>=2.2.0                       # Documentation Tool
 sphinx-rtd-theme==0.4.3             # Sphinx Theme
-sphinxcontrib-httpdomain==1.7.0     # API plugin for Readthedocs
+sphinxcontrib-httpdomain>=1.7.0     # API plugin for Readthedocs
 
-python-dateutil==2.8.1
+python-dateutil>=2.8.1

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,6 @@ setup(
         'Django>=3.1.3',
         'html2text>=2018.1.9',
         'twilio>=6.29.1',
-        'exponent_server_sdk>=0.3.1',
+        'exponent_server_sdk>=1.0.2',
         'python-dateutil>=2.8.1']
 )


### PR DESCRIPTION
This would be a sustainable fix for #30 with the downside that exponent_server_sdk <1.0.0 will not be compatible anymore.

Changed the classname `PushResponse` to `PushTicket` and included the message ID in the tests.

Since I do not use Expo myself and am not really familiar with its SDK, I would ask you to check the technical function one more time. I'm not sure what the impact of introducing the ID actually is.