### PR TITLE
Fix apps setup

### DIFF
--- a/django_notification_system/__init__.py
+++ b/django_notification_system/__init__.py
@@ -1,7 +1,0 @@
-from django.apps import AppConfig
-
-default_app_config = "django_notification_system.Config"
-
-
-class Config(AppConfig):
-    name = "django_notification_system"

--- a/django_notification_system/apps.py
+++ b/django_notification_system/apps.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-
-
 from django.apps import AppConfig
 
+default_app_config = "django_notification_system.Config"
 
-class Notifications(AppConfig):
-    name = 'Notifications'
+
+class Config(AppConfig):
+    name = "django_notification_system"


### PR DESCRIPTION
To fix the following issue that I had after installing `django-notification-system` with django `4.1.7`:

```python
Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/Users/leifdenby/git-repos/daisy-and-leif-website/.venv/lib/python3.10/site-packages/django/apps/config.py", line 210, in create
    app_module = import_module(app_name)
  File "/Volumes/agile/tooling/mambaforge/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'Notifications'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Volumes/agile/tooling/mambaforge/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/Volumes/agile/tooling/mambaforge/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/leifdenby/git-repos/daisy-and-leif-website/.venv/lib/python3.10/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/Users/leifdenby/git-repos/daisy-and-leif-website/.venv/lib/python3.10/site-packages/django/core/management/commands/runserver.py", line 125, in inner_run
    autoreload.raise_last_exception()
  File "/Users/leifdenby/git-repos/daisy-and-leif-website/.venv/lib/python3.10/site-packages/django/utils/autoreload.py", line 87, in raise_last_exception
    raise _exception[1]
  File "/Users/leifdenby/git-repos/daisy-and-leif-website/.venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 398, in execute
    autoreload.check_errors(django.setup)()
  File "/Users/leifdenby/git-repos/daisy-and-leif-website/.venv/lib/python3.10/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/Users/leifdenby/git-repos/daisy-and-leif-website/.venv/lib/python3.10/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/Users/leifdenby/git-repos/daisy-and-leif-website/.venv/lib/python3.10/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "/Users/leifdenby/git-repos/daisy-and-leif-website/.venv/lib/python3.10/site-packages/django/apps/config.py", line 212, in create
    raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Cannot import 'Notifications'. Check that 'django_notification_system.apps.Notifications.name' is correct.
```

I removed the superflous `AppConfig` in `__init__.py` and put into `apps.py` instead to resolve issue with django 4.1.7